### PR TITLE
ci(ci): change poetry link

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         uses: FedericoCarboni/setup-ffmpeg@v1
       - name: Install Poetry
         run: |
-          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
+          curl -sSL https://install.python-poetry.org | python3 - --version 1.2.0
           echo "$HOME/.poetry/bin" >> $GITHUB_PATH
       - name: Load cached dependencies
         id: cached-poetry-dependencies


### PR DESCRIPTION
## 概要 / Overview
<!-- どんな内容かざっくり記述 -->
CIのビルドに失敗していた問題修正

## 詳細 / Details
<!-- 何をしたか細かく記述 -->
CIで使うURL変更

## 関連Issue / Related issues
<!-- 既存のIssueのリンクを貼る (もしIssueがなかったら今作ろう) -->
https://github.com/python-poetry/poetry/issues/6377

## 参考 / References
<!-- 参考情報/リンク（懸念点や注意点などあれば記載） -->
- https://python-poetry.org/docs/#installing-with-the-official-installer
- [表示されたエラーの日本語訳](https://translate.google.co.jp/?hl=ja&sl=auto&tl=ja&text=Retrieving%20Poetry%20metadata%0A%0AThis%20installer%20is%20deprecated%2C%20and%20scheduled%20for%20removal%20from%20the%20Poetry%20repository%20on%20or%20after%20January%201%2C%202023.%0ASee%20https%3A%2F%2Fgithub.com%2Fpython-poetry%2Fpoetry%2Fissues%2F6377%20for%20details.%0A%0AYou%20should%20migrate%20to%20https%3A%2F%2Finstall.python-poetry.org%20instead%2C%20which%20supports%20all%20versions%20of%20Poetry%2C%20and%20allows%20for%20%60self%20update%60%20of%20versions%201.1.7%20or%20newer.%0AInstructions%20are%20available%20at%20https%3A%2F%2Fpython-poetry.org%2Fdocs%2F%23installation.%0A%0AWithout%20an%20explicit%20version%2C%20this%20installer%20will%20attempt%20to%20install%20the%20latest%20version%20of%20Poetry.%0AThis%20installer%20cannot%20install%20Poetry%201.2.0a1%20or%20newer%20(and%20installs%20will%20be%20unable%20to%20%60self%20update%60%20to%201.2.0a1%20or%20newer).%0A%0ATo%20continue%20to%20use%20this%20deprecated%20installer%2C%20you%20must%20specify%20an%20explicit%20version%20with%20--version%20%3Cversion%3E%20or%20POETRY_VERSION%3D%3Cversion%3E.%0AAlternatively%2C%20if%20you%20wish%20to%20force%20this%20deprecated%20installer%20to%20use%20the%20latest%20installable%20release%2C%20set%20GET_POETRY_IGNORE_DEPRECATION%3D1.%0A%0AVersion%201.2.0%20is%20not%20supported%20by%20this%20installer!%20Please%20specify%20a%20version%20prior%20to%201.2.0a1%20to%20continue!&op=translate)